### PR TITLE
Flush the filehandler when writing the NZB file

### DIFF
--- a/bin/newsup.pl
+++ b/bin/newsup.pl
@@ -345,7 +345,7 @@ sub upload_files {
         my $file_size   = -s $nzb_file;
         my $total_parts = ceil($file_size / (750 * 1024));
         my $ids         = generate_random_ids($total_parts, $options) if $options->{GENERATE_IDS};
-        my @articles    = ();
+        my @nzb_articles    = ();
         for (my $part = 1; $part <= $total_parts; $part++) {
             my $article = NewsUP::Article->new(
                 newsgroups  => $options->{GROUPS},
@@ -361,9 +361,9 @@ sub upload_files {
                 message_id  => $options->{GENERATE_IDS} ? $ids->[$part - 1] : undef,
                 obfuscate   => 0,
                 headers     => $options->{HEADERS});
-            push @articles, $article;
+            push @nzb_articles, $article;
         }
-        multiplexer($options, \@articles);
+        multiplexer($options, \@nzb_articles);
         print "NZB uploaded!" . ' ' x $options->{PROGRESSBAR_SIZE};
     }
 

--- a/build_scripts/arch_linux/PKGBUILD
+++ b/build_scripts/arch_linux/PKGBUILD
@@ -2,7 +2,7 @@
 pkgname=newsup-git
 _pkgname=newsup
 pkgrel=1
-pkgver=r426.521d69c
+pkgver=r427.cf16ce4
 provides=(_pkgname)
 pkgdesc="NewsUP - A usenet binary uploader"
 arch=('any')

--- a/lib/NewsUP/Utils.pm
+++ b/lib/NewsUP/Utils.pm
@@ -321,6 +321,9 @@ sub save_nzb {
     my $nzb_file = catfile($options->{NZB_SAVE_PATH}, $options->{NAME} // $options->{NZB_FILE});
     $nzb_file .= '.nzb' if $nzb_file !~ /\.nzb$/;
     open my $fh, '>:raw', $nzb_file or die "Unable to create the NZB: $!";
+    my $handler = select $fh;
+    $|=1;
+    select $handler;
     print $fh $nzb->serialize;
     close $fh;
     say "created nzb $nzb_file";


### PR DESCRIPTION
Flushes the filehandler when writing the NZB file, otherwise
when uploading the nzb file sometimes the nzb isn't completely written