### PR TITLE
Changed the article size in the config file to 700Kb

### DIFF
--- a/build_scripts/arch_linux/PKGBUILD
+++ b/build_scripts/arch_linux/PKGBUILD
@@ -2,7 +2,7 @@
 pkgname=newsup-git
 _pkgname=newsup
 pkgrel=1
-pkgver=r427.cf16ce4
+pkgver=r431.c0eb65b
 provides=(_pkgname)
 pkgdesc="NewsUP - A usenet binary uploader"
 arch=('any')

--- a/conf/newsup.conf
+++ b/conf/newsup.conf
@@ -15,8 +15,8 @@ password= myPassword
 uploader= NewsUP <NewsUP@somewhere.cbr>
 newsgroups= alt.binaries.test
 obfuscate = 0
-# default value 750KBytes
-size = 768000
+# default value 700KBytes
+size = 716800
 
 [headerCheck]
 enabled= 1


### PR DESCRIPTION
That are providers that sometimes loose articles. Downsizing to 700KBytes seems to help.